### PR TITLE
Adjacency fix

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -241,9 +241,6 @@
 	if(!choice_references["[choice[1]]"])
 		return 0
 
-	if(!Adjacent(choice_references["[choice[1]]"]))
-		return 0
-
 	var/atom/selA = choice_references["[choice[1]]"]
 	ClickOn(selA, choice.Copy(2))
 


### PR DESCRIPTION
`ClickOn` already contains adjacency checks where applicable, so these lines were redundant.